### PR TITLE
Switch to Libera.Chat

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,7 +10,7 @@
           <li>{{ site.title }} 2022 - TBD</li>
           <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
           <li><a href="/impressum/">Impressum</a>, <a href="https://github.com/tuebix/tuebixorg">Repository</a></li>
-          <li>inoffizieller Talk IRC: #tuebix (freenode)</li>
+          <li>inoffizieller Talk IRC: #tuebix (Libera.Chat)</li>
         <li><a href="https://twitter.com/tuebix">
             <span class="icon twitter">
               <svg version="1.1" class="twitter-icon-svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"


### PR DESCRIPTION
I hereby would like to propose to move the inofficial IRC chat from Freenode to Libera.Chat; background:

  * https://www.golem.de/news/irc-freenode-betreiber-ziehen-sich-zurueck-2105-156620.html
  * https://www.heise.de/news/IRC-Netz-Freenode-ist-tot-es-lebe-Libera-Chat-6050724.html

If this gets accepted, the old chat room should likely contain a redirecting topic for users and be set on moderated or so.