### PR TITLE
lottery.sh: Avoid using Bourne shell reserved variables

### DIFF
--- a/bin/lottery.sh
+++ b/bin/lottery.sh
@@ -22,7 +22,7 @@ ask_continue() {
 
 # Check the arguments:
 if [[ $# -lt 1 || $# -gt 2 ]]; then
-  echo "Usage: $(basename $0) ROWS [COLUMNS]"
+  echo "Usage: $(basename "$0") ROWS [COLUMNS]"
   echo "Got $# arguments, expecting 1 or 2 arguments"
   exit 1
 fi

--- a/bin/lottery.sh
+++ b/bin/lottery.sh
@@ -43,8 +43,8 @@ while [[ $number_of_winners -lt $(($rows*$columns)) ]]; do
 
   # Determine a new unique winner:
   while true; do
-    row=`shuf --input-range=1-$rows --head-count=1`
-    seat=`shuf --input-range=1-$columns --head-count=1`
+    row=$(shuf --input-range=1-$rows --head-count=1)
+    seat=$(shuf --input-range=1-$columns --head-count=1)
     id=$(($row*$columns + $seat))
     if [[ $row -eq 5 && $seat -gt 3 ]]; then
       continue # TODO: Only for 2019 (reserved seats)

--- a/bin/lottery.sh
+++ b/bin/lottery.sh
@@ -38,14 +38,14 @@ declare -i number_of_winners=0
 # Variables to determine the current winner
 declare -i row seat id
 
-while [[ $number_of_winners -lt $(($rows*$columns)) ]]; do
+while [[ $number_of_winners -lt $((rows*columns)) ]]; do
   clear
 
   # Determine a new unique winner:
   while true; do
     row=$(shuf --input-range=1-$rows --head-count=1)
     seat=$(shuf --input-range=1-$columns --head-count=1)
-    id=$(($row*$columns + $seat))
+    id=$((row*columns + seat))
     if [[ $row -eq 5 && $seat -gt 3 ]]; then
       continue # TODO: Only for 2019 (reserved seats)
     fi
@@ -53,7 +53,7 @@ while [[ $number_of_winners -lt $(($rows*$columns)) ]]; do
       continue # TODO: Only for 2019 (reserved seats)
     fi
     if [[ ! -v winners[$id] ]]; then
-      winners[$id]=1
+      winners[id]=1
       break
     fi
   done
@@ -69,9 +69,9 @@ while [[ $number_of_winners -lt $(($rows*$columns)) ]]; do
     echo "+-+"
     echo ""
   fi
-  for ((table_y=1; table_y <=$rows; table_y++))
+  for ((table_y=1; table_y <=rows; table_y++))
   do
-    for ((table_x=1; table_x <=$columns; table_x++))
+    for ((table_x=1; table_x <=columns; table_x++))
     do
       if [[ "$table_x" -eq "$seat" && "$table_y" -eq "$row" ]]
       then
@@ -87,6 +87,6 @@ while [[ $number_of_winners -lt $(($rows*$columns)) ]]; do
   ask_continue || break
 done
 
-if [[ $number_of_winners -eq $(($rows*$columns)) ]]; then
+if [[ $number_of_winners -eq $((rows*columns)) ]]; then
   echo "Maximum number of unique winners reached."
 fi

--- a/bin/lottery.sh
+++ b/bin/lottery.sh
@@ -28,8 +28,8 @@ if [[ $# -lt 1 || $# -gt 2 ]]; then
 fi
 
 # Parse the arguments:
-declare -ri ROWS="$1"
-declare -ri COLUMNS="${2:-8}"
+declare -ri rows="$1"
+declare -ri columns="${2:-8}"
 
 # Variable to force unique winners (no duplicates):
 declare -a winners
@@ -38,14 +38,14 @@ declare -i number_of_winners=0
 # Variables to determine the current winner
 declare -i row seat id
 
-while [[ $number_of_winners -lt $(($ROWS*$COLUMNS)) ]]; do
+while [[ $number_of_winners -lt $(($rows*$columns)) ]]; do
   clear
 
   # Determine a new unique winner:
   while true; do
-    row=`shuf --input-range=1-$ROWS --head-count=1`
-    seat=`shuf --input-range=1-$COLUMNS --head-count=1`
-    id=$(($row*$COLUMNS + $seat))
+    row=`shuf --input-range=1-$rows --head-count=1`
+    seat=`shuf --input-range=1-$columns --head-count=1`
+    id=$(($row*$columns + $seat))
     if [[ $row -eq 5 && $seat -gt 3 ]]; then
       continue # TODO: Only for 2019 (reserved seats)
     fi
@@ -63,15 +63,15 @@ while [[ $number_of_winners -lt $(($ROWS*$COLUMNS)) ]]; do
   echo -e "(Von vorne links)\n"
 
   # Draw the grid:
-  if [[ "$COLUMNS" -eq 8 ]]; then
+  if [[ "$columns" -eq 8 ]]; then
     echo "+-+"
     echo "|x|"
     echo "+-+"
     echo ""
   fi
-  for ((table_y=1; table_y <=$ROWS; table_y++))
+  for ((table_y=1; table_y <=$rows; table_y++))
   do
-    for ((table_x=1; table_x <=$COLUMNS; table_x++))
+    for ((table_x=1; table_x <=$columns; table_x++))
     do
       if [[ "$table_x" -eq "$seat" && "$table_y" -eq "$row" ]]
       then
@@ -87,6 +87,6 @@ while [[ $number_of_winners -lt $(($ROWS*$COLUMNS)) ]]; do
   ask_continue || break
 done
 
-if [[ $number_of_winners -eq $(($ROWS*$COLUMNS)) ]]; then
+if [[ $number_of_winners -eq $(($rows*$columns)) ]]; then
   echo "Maximum number of unique winners reached."
 fi


### PR DESCRIPTION
It's considered good shell coding style to use only lower-case variable names for own variables in on scripts, given variables introduced e.g. by the shell itself are usually all in capitales.

Fixes "line 88: COLUMNS: readonly variable", too.

See also: https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html